### PR TITLE
Claude/review ai guides 5k p bl

### DIFF
--- a/docs/5day/ai/feynman-method.md
+++ b/docs/5day/ai/feynman-method.md
@@ -1,103 +1,41 @@
-# Feynman Protocol: Recursive Feature Decomposition
+# Feynman Protocol: AI Execution Guide
 
-## Mission
+> **Theory:** [docs/5day/theory/feynman-method.md](../theory/feynman-method.md)
 
-Transform complex features into clear, actionable tasks using the Feynman Technique. No jargon. No ambiguity. Just plain English that anyone on the team can understand.
+## When to Use
 
-This protocol governs how features become tasks in 5DayDocs.
+Run this protocol when refining an idea in `docs/ideas/`. Typically triggered by `./5day.sh newidea <name>`.
 
-## The Four Phases
+## How to Execute
 
-### Phase 1: The Problem (What & Why)
+Work inside the idea file. Follow the four phases in order. Never skip a phase.
 
-**Goal:** Capture the human outcome, not the technical solution.
+### Phase 1-2: Interactive Discovery
 
-**Questions to ask:**
-- What problem does this solve?
-- Who benefits and how?
-- What does success look like?
+1. Read the idea file.
+2. Ask the user the Phase 1 questions (What problem? Who benefits? What does success look like?).
+3. Wait for answers. Do not assume or fill in.
+4. Rewrite answers in plain English (Phase 2). Flag any jargon and replace with analogies or plain definitions.
+5. Confirm with the user: "Does this capture it?"
 
-**Constraint:** Block implementation details. Words like "React," "Postgres," "microservice" are premature. Focus on the *job to be done*.
+### Phase 3: Decomposition
 
-**Validation:** "If this feature were a person, what job would they be hired to do?"
+1. Break the feature into atomic pieces.
+2. Present each piece to the user with a tag: `[READY]`, `[RESEARCH]`, or `[BLOCKED]`.
+3. Ask the user to validate the tags.
+4. Resolve any `[BLOCKED]` items before proceeding.
 
----
+### Phase 4: Task Generation
 
-### Phase 2: Plain English (Clarity Filter)
+1. Only proceed after the user confirms the Phase 3 breakdown.
+2. Convert `[READY]` items into task files in `docs/tasks/backlog/`.
+3. Each task title: 10 words max.
+4. Each task must be completable independently.
+5. If a task feels too broad, recurse it through Phase 3.
 
-**Goal:** Rewrite Phase 1 so any team member—regardless of role—can understand it.
+## Rules
 
-**Jargon detection:** Flag technical terms (API, backend, database, interface, endpoint, etc.). When detected:
-- Replace with analogies ("a messenger," "a filing cabinet," "a gatekeeper")
-- Or define in one plain sentence
-
-**Success test:** Could a new hire with no project context understand this?
-
----
-
-### Phase 3: Decomposition (Gap Audit)
-
-**Goal:** Break the feature into atomic pieces and validate each one.
-
-**For each piece, ask:** *"Do we have everything needed to build this right now?"*
-
-**Tag each piece:**
-- `[READY]` — Clear path forward. Can become a task.
-- `[RESEARCH]` — Knowledge gap. Needs investigation first.
-- `[BLOCKED]` — Dependency or logical gap (e.g., "Can't send emails without a sender address").
-
-**Output:** A list of atomic operations with their tags.
-
----
-
-### Phase 4: Task Generation (Build Instructions)
-
-**Goal:** Convert `[READY]` items into task descriptions.
-
-**Constraints:**
-- Each task title: 10 words max
-- Each task should be completable independently
-- If a task feels "heavy," recurse: run it through Phase 3 again
-
-**Output:** Task files in `docs/tasks/backlog/`
-
----
-
-## Workflow
-
-```
-docs/ideas/     → Raw ideas being refined (this protocol)
-docs/features/  → Fully defined features
-docs/tasks/*/*  → Actionable work items
-```
-
-### CLI Usage
-
-```bash
-./5day.sh newidea "User notifications"
-```
-
-Creates `docs/ideas/user-notifications.md` with embedded instructions.
-
----
-
-## For AI Agents
-
-When running this protocol:
-
-1. **Phase 1-2:** Interactive. Ask questions, wait for answers. Don't assume.
-2. **Phase 3:** Present decomposition, ask user to validate tags.
-3. **Phase 4:** Generate tasks only after user confirms the breakdown.
-
-Work within the idea file. Never skip phases.
-
----
-
-## Error States
-
-| Condition | Action |
-|-----------|--------|
-| Jargon detected in Phase 2 | Flag it. Rewrite with analogy. |
-| `[BLOCKED]` item in Phase 3 | Cannot proceed to Phase 4 until resolved. |
-| Task too broad in Phase 4 | Recurse to Phase 3 for that item. |
-
+- Work within the idea file. Update it as you go.
+- Ask questions, wait for answers. Don't fill sections without user input.
+- One phase at a time. Confirm before advancing.
+- `[BLOCKED]` items halt progress to Phase 4 until resolved.

--- a/docs/5day/scripts/create-idea.sh
+++ b/docs/5day/scripts/create-idea.sh
@@ -67,37 +67,48 @@ This document helps refine a rough idea into a clear definition.
 
 ## Phase 1: The Problem
 
-<!-- What problem does this solve? Who has this problem?
-     What happens if we don't solve it? Be specific about the pain point. -->
+<!-- What problem does this solve? Who specifically has this problem?
+     What happens if we don't solve it? Be specific about the pain point.
+     Name a real person or role who would benefit. -->
 
+**The problem:**
 
+**Who has it:**
+
+**What happens without it:**
 
 ---
 
 ## Phase 2: Plain English
 
 <!-- Describe this idea so anyone on the team can understand it.
-     Use everyday language. If you catch yourself using jargon, rephrase it. -->
+     Use everyday language. If you catch yourself using jargon, rephrase it.
+     Could a new hire with no project context understand this? -->
 
 
 
 ---
 
-## Phase 3: What It Does
+## Phase 3: Decomposition
 
-<!-- List concrete capabilities this idea enables.
-     Each should be something you can demonstrate or test. -->
+<!-- Break this idea into its smallest parts. For each part, tag it:
+     [READY]    - Clear enough to become a task right now
+     [RESEARCH] - Needs investigation before it can move forward
+     [BLOCKED]  - Depends on something else being resolved first
 
-- [ ]
-- [ ]
-- [ ]
+     If a part feels too big, break it down further. -->
+
+- [ ] `[READY]`
+- [ ] `[RESEARCH]`
+- [ ] `[BLOCKED]`
 
 ---
 
 ## Phase 4: Open Questions
 
-<!-- What's still unclear? What needs research? What assumptions are we making?
-     It's good to capture uncertainty here. -->
+<!-- What's still unclear? What assumptions are we making?
+     List anything tagged [RESEARCH] or [BLOCKED] above and what
+     needs to happen to resolve it. -->
 
 -
 
@@ -107,11 +118,28 @@ This document helps refine a rough idea into a clear definition.
 
 <!-- Any additional context, links, or references. -->
 
+---
+
+## Ready to Graduate?
+
+Before promoting this idea to a feature, verify:
+
+- [ ] Phase 1 names a specific person or role who benefits
+- [ ] Phase 2 is understandable by someone with no project context
+- [ ] Phase 3 has no unresolved `[BLOCKED]` items
+- [ ] Phase 3 has no unresolved `[RESEARCH]` items
+- [ ] Every `[READY]` item is small enough to be a single task
+
+```bash
+./5day.sh promote KEBAB_CASE_PLACEHOLDER
+```
+
 EOL
 
 # Replace placeholders (escape user input for sed safety)
 sed_inplace "s/IDEA_NAME_PLACEHOLDER/$(sed_escape "$IDEA_NAME")/g" "$IDEA_FILE"
 sed_inplace "s/CREATED_DATE_PLACEHOLDER/$(date +%Y-%m-%d)/g" "$IDEA_FILE"
+sed_inplace "s/KEBAB_CASE_PLACEHOLDER/$(sed_escape "$KEBAB_CASE")/g" "$IDEA_FILE"
 
 # Stage the changes
 git add "$IDEA_FILE"

--- a/docs/5day/theory/feynman-method.md
+++ b/docs/5day/theory/feynman-method.md
@@ -1,0 +1,80 @@
+# Feynman Protocol: Recursive Feature Decomposition
+
+## Purpose
+
+Transform complex features into clear, actionable tasks using the Feynman Technique. No jargon. No ambiguity. Just plain English that anyone on the team can understand.
+
+## The Four Phases
+
+### Phase 1: The Problem (What & Why)
+
+**Goal:** Capture the human outcome, not the technical solution.
+
+**Questions to ask:**
+- What problem does this solve?
+- Who benefits and how?
+- What does success look like?
+
+**Constraint:** Block implementation details. Words like "React," "Postgres," "microservice" are premature. Focus on the *job to be done*.
+
+**Validation:** "If this feature were a person, what job would they be hired to do?"
+
+---
+
+### Phase 2: Plain English (Clarity Filter)
+
+**Goal:** Rewrite Phase 1 so any team member—regardless of role—can understand it.
+
+**Jargon detection:** Flag technical terms (API, backend, database, interface, endpoint, etc.). When detected:
+- Replace with analogies ("a messenger," "a filing cabinet," "a gatekeeper")
+- Or define in one plain sentence
+
+**Success test:** Could a new hire with no project context understand this?
+
+---
+
+### Phase 3: Decomposition (Gap Audit)
+
+**Goal:** Break the feature into atomic pieces and validate each one.
+
+**For each piece, ask:** *"Do we have everything needed to build this right now?"*
+
+**Tag each piece:**
+- `[READY]` — Clear path forward. Can become a task.
+- `[RESEARCH]` — Knowledge gap. Needs investigation first.
+- `[BLOCKED]` — Dependency or logical gap (e.g., "Can't send emails without a sender address").
+
+**Output:** A list of atomic operations with their tags.
+
+---
+
+### Phase 4: Task Generation (Build Instructions)
+
+**Goal:** Convert `[READY]` items into task descriptions.
+
+**Constraints:**
+- Each task title: 10 words max
+- Each task should be completable independently
+- If a task feels "heavy," recurse: run it through Phase 3 again
+
+**Output:** Task files in `docs/tasks/backlog/`
+
+---
+
+## Workflow
+
+```
+docs/ideas/     -> Raw ideas being refined (this protocol)
+docs/features/  -> Fully defined features
+docs/tasks/*/*  -> Actionable work items
+```
+
+---
+
+## Error States
+
+| Condition | Action |
+|-----------|--------|
+| Jargon detected in Phase 2 | Flag it. Rewrite with analogy. |
+| `[BLOCKED]` item in Phase 3 | Cannot proceed to Phase 4 until resolved. |
+| Task too broad in Phase 4 | Recurse to Phase 3 for that item. |

--- a/docs/ideas/TEMPLATE-idea.md
+++ b/docs/ideas/TEMPLATE-idea.md
@@ -22,37 +22,48 @@ This document helps refine a rough idea into a clear definition.
 
 ## Phase 1: The Problem
 
-<!-- What problem does this solve? Who has this problem?
-     What happens if we don't solve it? Be specific about the pain point. -->
+<!-- What problem does this solve? Who specifically has this problem?
+     What happens if we don't solve it? Be specific about the pain point.
+     Name a real person or role who would benefit. -->
 
+**The problem:**
 
+**Who has it:**
+
+**What happens without it:**
 
 ---
 
 ## Phase 2: Plain English
 
 <!-- Describe this idea so anyone on the team can understand it.
-     Use everyday language. If you catch yourself using jargon, rephrase it. -->
+     Use everyday language. If you catch yourself using jargon, rephrase it.
+     Could a new hire with no project context understand this? -->
 
 
 
 ---
 
-## Phase 3: What It Does
+## Phase 3: Decomposition
 
-<!-- List concrete capabilities this idea enables.
-     Each should be something you can demonstrate or test. -->
+<!-- Break this idea into its smallest parts. For each part, tag it:
+     [READY]    - Clear enough to become a task right now
+     [RESEARCH] - Needs investigation before it can move forward
+     [BLOCKED]  - Depends on something else being resolved first
 
-- [ ]
-- [ ]
-- [ ]
+     If a part feels too big, break it down further. -->
+
+- [ ] `[READY]`
+- [ ] `[RESEARCH]`
+- [ ] `[BLOCKED]`
 
 ---
 
 ## Phase 4: Open Questions
 
-<!-- What's still unclear? What needs research? What assumptions are we making?
-     It's good to capture uncertainty here. -->
+<!-- What's still unclear? What assumptions are we making?
+     List anything tagged [RESEARCH] or [BLOCKED] above and what
+     needs to happen to resolve it. -->
 
 -
 
@@ -61,3 +72,19 @@ This document helps refine a rough idea into a clear definition.
 ## Notes
 
 <!-- Any additional context, links, or references. -->
+
+---
+
+## Ready to Graduate?
+
+Before promoting this idea to a feature, verify:
+
+- [ ] Phase 1 names a specific person or role who benefits
+- [ ] Phase 2 is understandable by someone with no project context
+- [ ] Phase 3 has no unresolved `[BLOCKED]` items
+- [ ] Phase 3 has no unresolved `[RESEARCH]` items
+- [ ] Every `[READY]` item is small enough to be a single task
+
+```bash
+./5day.sh promote [idea-name]
+```

--- a/docs/ideas/special-sauce.md
+++ b/docs/ideas/special-sauce.md
@@ -72,7 +72,7 @@ That question forces a choice—pick one thing, then build the smallest test of 
 
 **All resolved:**
 - Command: `./5day.sh sauce` (new functionality)
-- Human + AI powered: AI instructions go in `docs/5day/ai/` alongside `feynman-method.md`
+- Human + AI powered: AI instructions go in `docs/5day/ai/`, theory in `docs/5day/theory/`
 - Fallback scaffolding: If user can't articulate sauce directly, walk them through:
   1. "What's your why?" (motivation)
   2. "What's the problem we're solving?" (problem)

--- a/docs/tasks/live/101-test-app-structure-and-installation.md
+++ b/docs/tasks/live/101-test-app-structure-and-installation.md
@@ -30,6 +30,8 @@ src/
 │       ├── ai/
 │       │   ├── .gitkeep
 │       │   └── feynman-method.md
+│       ├── theory/
+│       │   └── feynman-method.md
 │       └── scripts/
 │           ├── 5day.sh
 │           ├── ai-context.sh

--- a/docs/tasks/review/95-ensure-ai-understand-5daydocs-vs-project-files.md
+++ b/docs/tasks/review/95-ensure-ai-understand-5daydocs-vs-project-files.md
@@ -123,7 +123,8 @@ AI agents reading `DOCUMENTATION.md` immediately understand:
 ├── setup.sh                 ← Full installer/updater (NOT distributed)
 ├── 5day.sh                  ← CLI (synced from src/)
 ├── src/docs/5day/scripts/   ← Source of truth for distributed scripts
-├── src/docs/5day/ai/        ← AI instructions (feynman-method.md)
+├── src/docs/5day/ai/        ← AI execution guides
+├── src/docs/5day/theory/    ← Methodology (feynman-method.md)
 └── docs/5day/               ← Dogfood copy
 ```
 

--- a/src/docs/5day/ai/feynman-method.md
+++ b/src/docs/5day/ai/feynman-method.md
@@ -1,103 +1,41 @@
-# Feynman Protocol: Recursive Feature Decomposition
+# Feynman Protocol: AI Execution Guide
 
-## Mission
+> **Theory:** [docs/5day/theory/feynman-method.md](../theory/feynman-method.md)
 
-Transform complex features into clear, actionable tasks using the Feynman Technique. No jargon. No ambiguity. Just plain English that anyone on the team can understand.
+## When to Use
 
-This protocol governs how features become tasks in 5DayDocs.
+Run this protocol when refining an idea in `docs/ideas/`. Typically triggered by `./5day.sh newidea <name>`.
 
-## The Four Phases
+## How to Execute
 
-### Phase 1: The Problem (What & Why)
+Work inside the idea file. Follow the four phases in order. Never skip a phase.
 
-**Goal:** Capture the human outcome, not the technical solution.
+### Phase 1-2: Interactive Discovery
 
-**Questions to ask:**
-- What problem does this solve?
-- Who benefits and how?
-- What does success look like?
+1. Read the idea file.
+2. Ask the user the Phase 1 questions (What problem? Who benefits? What does success look like?).
+3. Wait for answers. Do not assume or fill in.
+4. Rewrite answers in plain English (Phase 2). Flag any jargon and replace with analogies or plain definitions.
+5. Confirm with the user: "Does this capture it?"
 
-**Constraint:** Block implementation details. Words like "React," "Postgres," "microservice" are premature. Focus on the *job to be done*.
+### Phase 3: Decomposition
 
-**Validation:** "If this feature were a person, what job would they be hired to do?"
+1. Break the feature into atomic pieces.
+2. Present each piece to the user with a tag: `[READY]`, `[RESEARCH]`, or `[BLOCKED]`.
+3. Ask the user to validate the tags.
+4. Resolve any `[BLOCKED]` items before proceeding.
 
----
+### Phase 4: Task Generation
 
-### Phase 2: Plain English (Clarity Filter)
+1. Only proceed after the user confirms the Phase 3 breakdown.
+2. Convert `[READY]` items into task files in `docs/tasks/backlog/`.
+3. Each task title: 10 words max.
+4. Each task must be completable independently.
+5. If a task feels too broad, recurse it through Phase 3.
 
-**Goal:** Rewrite Phase 1 so any team member—regardless of role—can understand it.
+## Rules
 
-**Jargon detection:** Flag technical terms (API, backend, database, interface, endpoint, etc.). When detected:
-- Replace with analogies ("a messenger," "a filing cabinet," "a gatekeeper")
-- Or define in one plain sentence
-
-**Success test:** Could a new hire with no project context understand this?
-
----
-
-### Phase 3: Decomposition (Gap Audit)
-
-**Goal:** Break the feature into atomic pieces and validate each one.
-
-**For each piece, ask:** *"Do we have everything needed to build this right now?"*
-
-**Tag each piece:**
-- `[READY]` — Clear path forward. Can become a task.
-- `[RESEARCH]` — Knowledge gap. Needs investigation first.
-- `[BLOCKED]` — Dependency or logical gap (e.g., "Can't send emails without a sender address").
-
-**Output:** A list of atomic operations with their tags.
-
----
-
-### Phase 4: Task Generation (Build Instructions)
-
-**Goal:** Convert `[READY]` items into task descriptions.
-
-**Constraints:**
-- Each task title: 10 words max
-- Each task should be completable independently
-- If a task feels "heavy," recurse: run it through Phase 3 again
-
-**Output:** Task files in `docs/tasks/backlog/`
-
----
-
-## Workflow
-
-```
-docs/ideas/     → Raw ideas being refined (this protocol)
-docs/features/  → Fully defined features
-docs/tasks/*/*  → Actionable work items
-```
-
-### CLI Usage
-
-```bash
-./5day.sh newidea "User notifications"
-```
-
-Creates `docs/ideas/user-notifications.md` with embedded instructions.
-
----
-
-## For AI Agents
-
-When running this protocol:
-
-1. **Phase 1-2:** Interactive. Ask questions, wait for answers. Don't assume.
-2. **Phase 3:** Present decomposition, ask user to validate tags.
-3. **Phase 4:** Generate tasks only after user confirms the breakdown.
-
-Work within the idea file. Never skip phases.
-
----
-
-## Error States
-
-| Condition | Action |
-|-----------|--------|
-| Jargon detected in Phase 2 | Flag it. Rewrite with analogy. |
-| `[BLOCKED]` item in Phase 3 | Cannot proceed to Phase 4 until resolved. |
-| Task too broad in Phase 4 | Recurse to Phase 3 for that item. |
-
+- Work within the idea file. Update it as you go.
+- Ask questions, wait for answers. Don't fill sections without user input.
+- One phase at a time. Confirm before advancing.
+- `[BLOCKED]` items halt progress to Phase 4 until resolved.

--- a/src/docs/5day/scripts/create-idea.sh
+++ b/src/docs/5day/scripts/create-idea.sh
@@ -67,37 +67,48 @@ This document helps refine a rough idea into a clear definition.
 
 ## Phase 1: The Problem
 
-<!-- What problem does this solve? Who has this problem?
-     What happens if we don't solve it? Be specific about the pain point. -->
+<!-- What problem does this solve? Who specifically has this problem?
+     What happens if we don't solve it? Be specific about the pain point.
+     Name a real person or role who would benefit. -->
 
+**The problem:**
 
+**Who has it:**
+
+**What happens without it:**
 
 ---
 
 ## Phase 2: Plain English
 
 <!-- Describe this idea so anyone on the team can understand it.
-     Use everyday language. If you catch yourself using jargon, rephrase it. -->
+     Use everyday language. If you catch yourself using jargon, rephrase it.
+     Could a new hire with no project context understand this? -->
 
 
 
 ---
 
-## Phase 3: What It Does
+## Phase 3: Decomposition
 
-<!-- List concrete capabilities this idea enables.
-     Each should be something you can demonstrate or test. -->
+<!-- Break this idea into its smallest parts. For each part, tag it:
+     [READY]    - Clear enough to become a task right now
+     [RESEARCH] - Needs investigation before it can move forward
+     [BLOCKED]  - Depends on something else being resolved first
 
-- [ ]
-- [ ]
-- [ ]
+     If a part feels too big, break it down further. -->
+
+- [ ] `[READY]`
+- [ ] `[RESEARCH]`
+- [ ] `[BLOCKED]`
 
 ---
 
 ## Phase 4: Open Questions
 
-<!-- What's still unclear? What needs research? What assumptions are we making?
-     It's good to capture uncertainty here. -->
+<!-- What's still unclear? What assumptions are we making?
+     List anything tagged [RESEARCH] or [BLOCKED] above and what
+     needs to happen to resolve it. -->
 
 -
 
@@ -107,11 +118,28 @@ This document helps refine a rough idea into a clear definition.
 
 <!-- Any additional context, links, or references. -->
 
+---
+
+## Ready to Graduate?
+
+Before promoting this idea to a feature, verify:
+
+- [ ] Phase 1 names a specific person or role who benefits
+- [ ] Phase 2 is understandable by someone with no project context
+- [ ] Phase 3 has no unresolved `[BLOCKED]` items
+- [ ] Phase 3 has no unresolved `[RESEARCH]` items
+- [ ] Every `[READY]` item is small enough to be a single task
+
+```bash
+./5day.sh promote KEBAB_CASE_PLACEHOLDER
+```
+
 EOL
 
 # Replace placeholders (escape user input for sed safety)
 sed_inplace "s/IDEA_NAME_PLACEHOLDER/$(sed_escape "$IDEA_NAME")/g" "$IDEA_FILE"
 sed_inplace "s/CREATED_DATE_PLACEHOLDER/$(date +%Y-%m-%d)/g" "$IDEA_FILE"
+sed_inplace "s/KEBAB_CASE_PLACEHOLDER/$(sed_escape "$KEBAB_CASE")/g" "$IDEA_FILE"
 
 # Stage the changes
 git add "$IDEA_FILE"

--- a/src/docs/5day/theory/feynman-method.md
+++ b/src/docs/5day/theory/feynman-method.md
@@ -1,0 +1,80 @@
+# Feynman Protocol: Recursive Feature Decomposition
+
+## Purpose
+
+Transform complex features into clear, actionable tasks using the Feynman Technique. No jargon. No ambiguity. Just plain English that anyone on the team can understand.
+
+## The Four Phases
+
+### Phase 1: The Problem (What & Why)
+
+**Goal:** Capture the human outcome, not the technical solution.
+
+**Questions to ask:**
+- What problem does this solve?
+- Who benefits and how?
+- What does success look like?
+
+**Constraint:** Block implementation details. Words like "React," "Postgres," "microservice" are premature. Focus on the *job to be done*.
+
+**Validation:** "If this feature were a person, what job would they be hired to do?"
+
+---
+
+### Phase 2: Plain English (Clarity Filter)
+
+**Goal:** Rewrite Phase 1 so any team member—regardless of role—can understand it.
+
+**Jargon detection:** Flag technical terms (API, backend, database, interface, endpoint, etc.). When detected:
+- Replace with analogies ("a messenger," "a filing cabinet," "a gatekeeper")
+- Or define in one plain sentence
+
+**Success test:** Could a new hire with no project context understand this?
+
+---
+
+### Phase 3: Decomposition (Gap Audit)
+
+**Goal:** Break the feature into atomic pieces and validate each one.
+
+**For each piece, ask:** *"Do we have everything needed to build this right now?"*
+
+**Tag each piece:**
+- `[READY]` — Clear path forward. Can become a task.
+- `[RESEARCH]` — Knowledge gap. Needs investigation first.
+- `[BLOCKED]` — Dependency or logical gap (e.g., "Can't send emails without a sender address").
+
+**Output:** A list of atomic operations with their tags.
+
+---
+
+### Phase 4: Task Generation (Build Instructions)
+
+**Goal:** Convert `[READY]` items into task descriptions.
+
+**Constraints:**
+- Each task title: 10 words max
+- Each task should be completable independently
+- If a task feels "heavy," recurse: run it through Phase 3 again
+
+**Output:** Task files in `docs/tasks/backlog/`
+
+---
+
+## Workflow
+
+```
+docs/ideas/     -> Raw ideas being refined (this protocol)
+docs/features/  -> Fully defined features
+docs/tasks/*/*  -> Actionable work items
+```
+
+---
+
+## Error States
+
+| Condition | Action |
+|-----------|--------|
+| Jargon detected in Phase 2 | Flag it. Rewrite with analogy. |
+| `[BLOCKED]` item in Phase 3 | Cannot proceed to Phase 4 until resolved. |
+| Task too broad in Phase 4 | Recurse to Phase 3 for that item. |

--- a/src/templates/project/TEMPLATE-idea.md
+++ b/src/templates/project/TEMPLATE-idea.md
@@ -23,37 +23,48 @@ This document helps refine a rough idea into a clear definition.
 
 ## Phase 1: The Problem
 
-<!-- What problem does this solve? Who has this problem?
-     What happens if we don't solve it? Be specific about the pain point. -->
+<!-- What problem does this solve? Who specifically has this problem?
+     What happens if we don't solve it? Be specific about the pain point.
+     Name a real person or role who would benefit. -->
 
+**The problem:**
 
+**Who has it:**
+
+**What happens without it:**
 
 ---
 
 ## Phase 2: Plain English
 
 <!-- Describe this idea so anyone on the team can understand it.
-     Use everyday language. If you catch yourself using jargon, rephrase it. -->
+     Use everyday language. If you catch yourself using jargon, rephrase it.
+     Could a new hire with no project context understand this? -->
 
 
 
 ---
 
-## Phase 3: What It Does
+## Phase 3: Decomposition
 
-<!-- List concrete capabilities this idea enables.
-     Each should be something you can demonstrate or test. -->
+<!-- Break this idea into its smallest parts. For each part, tag it:
+     [READY]    - Clear enough to become a task right now
+     [RESEARCH] - Needs investigation before it can move forward
+     [BLOCKED]  - Depends on something else being resolved first
 
-- [ ]
-- [ ]
-- [ ]
+     If a part feels too big, break it down further. -->
+
+- [ ] `[READY]`
+- [ ] `[RESEARCH]`
+- [ ] `[BLOCKED]`
 
 ---
 
 ## Phase 4: Open Questions
 
-<!-- What's still unclear? What needs research? What assumptions are we making?
-     It's good to capture uncertainty here. -->
+<!-- What's still unclear? What assumptions are we making?
+     List anything tagged [RESEARCH] or [BLOCKED] above and what
+     needs to happen to resolve it. -->
 
 -
 


### PR DESCRIPTION
Split feynman-method.md into theory and AI execution guide — methodology now lives in docs/5day/theory/, while docs/5day/ai/ keeps a slim, step-by-step execution guide that references the theory

Aligned idea template with the Feynman protocol — Phase 3 renamed from "What It Does" to "Decomposition" with [READY]/[RESEARCH]/[BLOCKED] readiness tags; Phase 1 now prompts for structured problem/who/consequence

Added "Ready to Graduate?" quality gate to the idea template — 5 concrete checks that must pass before an idea can be promoted to a feature

Updated all references across templates, scripts (both docs/ and src/), ideas, and task files